### PR TITLE
added feature computation for specific populations and moved feature computation to model building

### DIFF
--- a/saxskit/saxs_models.py
+++ b/saxskit/saxs_models.py
@@ -405,12 +405,16 @@ def get_data_from_Citrination(client, dataset_id_list):
         pifs = [x.system for x in all_hits]
 
         for pp in pifs:
-            feats = OrderedDict.fromkeys(saxs_math.profile_keys+saxs_math.form_factor_profile_keys)
+            feats = OrderedDict.fromkeys(saxs_math.profile_keys
+                +saxs_math.spherical_normal_profile_keys
+                +saxs_math.guinier_porod_profile_keys)
             pops = OrderedDict.fromkeys(saxs_math.population_keys)
             par = OrderedDict.fromkeys(saxs_math.parameter_keys)
             expt_id,t_utc,q_I,temp,pif_feats,pif_pops,pif_par,rpt = saxs_piftools.unpack_pif(pp)
 
-            feats.update(pif_feats)
+            #feats.update(pif_feats)
+            feats.update(saxs_math.profile_spectrum(q_I))
+            feats.update(saxs_math.population_profiles(q_I,pif_pops,pif_par))
             pops.update(pif_pops)
             par.update(pif_par)
             data_row = [expt_id]+list(feats.values())+list(pops.values())+list(par.values())

--- a/saxskit/saxs_piftools.py
+++ b/saxskit/saxs_piftools.py
@@ -126,14 +126,11 @@ def saxs_properties(q_I,temp_C,populations,params):
         prof = saxs_math.profile_spectrum(q_I)
         prof_props = profile_properties(prof)
         props.extend(prof_props)
-        if populations is not None:
+        if populations is not None and params is not None:
             # population-specific featurizations
-            if bool(populations['spherical_normal']) \
-            and not bool(populations['unidentified']) \
-            and not bool(populations['diffraction_peaks']):
-                spher_prof = saxs_math.profile_form_factor_spectrum(q_I)
-                spher_prof_props = profile_properties(spher_prof)
-                props.extend(spher_prof_props)
+            pop_profiles = saxs_math.population_profiles(q_I,populations,params)
+            pop_profile_props = profile_properties(pop_profiles)
+            props.extend(pop_profile_props)
         # ML flags for this featurization
         sxc = saxs_classify.SaxsClassifier()
         ml_pops = sxc.classify(np.array(list(prof.values())).reshape(1,-1))

--- a/tests/test_saxskit.py
+++ b/tests/test_saxskit.py
@@ -41,7 +41,6 @@ def test_classifier():
             for pk,pop in pops.items():
                 print('\t{} populations: {} ({} certainty)'.format(pk,pop[0],pop[1]))
 
-#if __name__ == '__main__':
-#    test_guinier_porod()
-#    test_spherical_normal_saxs()
+# TODO: next, test_regressions()
+# TODO: then, test_population_profiles()
 


### PR DESCRIPTION
github had a hard time figuring out the diffs on this, because I moved a large function within saxs_math.py, from the middle of the module to the bottom.

Basically, here is what I did:
1) I added methods like saxs_math.profile_spectrum(), but for our distinct populations. One method for "guinier_porod" and one for "spherical_normal".
2) I used saxs_math.profile_spectrum() and also these two new methods to compute the features of the spectrum. So, in saxs_models.get_data_from_Citrination(), it gets the q_I array, the populations, and the fit parameters from the pif record, but then it calls on saxs_math.profile_spectrum() and saxs_math.population_profiles() to get the feature set, instead of taking these features directly from the records.